### PR TITLE
[Add admin login func][admin] 管理者画面に管理者ログイン機能を追加

### DIFF
--- a/app/Http/Controllers/Admin/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Admin/Auth/AuthenticatedSessionController.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Controllers\Admin\Auth;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Auth\LoginRequest;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Route;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class AuthenticatedSessionController extends Controller
+{
+    public function create(): Response
+    {
+        return Inertia::render('Admin/Auth/Login', [
+            'canResetPassword' => Route::has('admin.password.request'),
+            'status' => session('status'),
+        ]);
+    }
+
+    public function store(LoginRequest $request): RedirectResponse
+    {
+        $request->authenticate();
+
+        $request->session()->regenerate();
+
+        return redirect()->intended(route('admin.dashboard', absolute: false));
+    }
+}

--- a/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -47,6 +47,6 @@ class AuthenticatedSessionController extends Controller
 
         $request->session()->regenerateToken();
 
-        return redirect('/');
+        return to_route('login');
     }
 }

--- a/app/Http/Requests/Auth/LoginRequest.php
+++ b/app/Http/Requests/Auth/LoginRequest.php
@@ -41,7 +41,13 @@ class LoginRequest extends FormRequest
     {
         $this->ensureIsNotRateLimited();
 
-        if (! Auth::attempt($this->only('email', 'password'), $this->boolean('remember'))) {
+        if ($this->routeIs('admin.*')) {
+            $guard = 'admin';
+        } else {
+            $guard = 'web';
+        }
+
+        if (!Auth::guard($guard)->attempt($this->only('email', 'password'), $this->boolean('remember'))) {
             RateLimiter::hit($this->throttleKey());
 
             throw ValidationException::withMessages([
@@ -59,7 +65,7 @@ class LoginRequest extends FormRequest
      */
     public function ensureIsNotRateLimited(): void
     {
-        if (! RateLimiter::tooManyAttempts($this->throttleKey(), 5)) {
+        if (!RateLimiter::tooManyAttempts($this->throttleKey(), 5)) {
             return;
         }
 
@@ -80,6 +86,6 @@ class LoginRequest extends FormRequest
      */
     public function throttleKey(): string
     {
-        return Str::transliterate(Str::lower($this->string('email')).'|'.$this->ip());
+        return Str::transliterate(Str::lower($this->string('email')) . '|' . $this->ip());
     }
 }

--- a/app/Models/Admin.php
+++ b/app/Models/Admin.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Notifications\Notifiable;
+
+class Admin extends Authenticatable implements MustVerifyEmail
+{
+    use HasFactory, Notifiable;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'name',
+        'email',
+        'password',
+    ];
+
+    /**
+     * The attributes that should be hidden for serialization.
+     *
+     * @var array<int, string>
+     */
+    protected $hidden = [
+        'password',
+        'remember_token',
+    ];
+
+    /**
+     * Get the attributes that should be cast.
+     *
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'email_verified_at' => 'datetime',
+            'password' => 'hashed',
+        ];
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -19,6 +19,7 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        $cookieName = request()->is('admin*') ? 'session.cookie_admin' : 'session.cookie';
+        config(['session.cookie' => config($cookieName)]);
     }
 }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -6,8 +6,8 @@ use Illuminate\Foundation\Configuration\Middleware;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
-        web: __DIR__.'/../routes/web.php',
-        commands: __DIR__.'/../routes/console.php',
+        web: __DIR__ . '/../routes/web.php',
+        commands: __DIR__ . '/../routes/console.php',
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {
@@ -16,7 +16,17 @@ return Application::configure(basePath: dirname(__DIR__))
             \Illuminate\Http\Middleware\AddLinkHeadersForPreloadedAssets::class,
         ]);
 
-        //
+        $middleware->redirectGuestsTo(function ($request) {
+            return $request->is('admin*') ? route('admin.login') : route('login');
+        });
+        $middleware->redirectUsersTo(function ($request) {
+            if ($request->is('admin/login') && auth()->guard('admin')->check()) {
+                return route('admin.dashboard');
+            } elseif ($request->is('login') && auth()->guard('web')->check()) {
+                return route('dashboard');
+            }
+            return null;
+        });
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //

--- a/config/auth.php
+++ b/config/auth.php
@@ -40,6 +40,10 @@ return [
             'driver' => 'session',
             'provider' => 'users',
         ],
+        'admin' => [
+            'driver' => 'session',
+            'provider' => 'admins',
+        ],
     ],
 
     /*
@@ -63,6 +67,11 @@ return [
         'users' => [
             'driver' => 'eloquent',
             'model' => env('AUTH_MODEL', App\Models\User::class),
+        ],
+
+        'admins' => [
+            'driver' => 'eloquent',
+            'model' => App\Models\Admin::class,
         ],
 
         // 'users' => [
@@ -94,6 +103,12 @@ return [
         'users' => [
             'provider' => 'users',
             'table' => env('AUTH_PASSWORD_RESET_TOKEN_TABLE', 'password_reset_tokens'),
+            'expire' => 60,
+            'throttle' => 60,
+        ],
+        'admins' => [
+            'provider' => 'admins',
+            'table' => env('AUTH_PASSWORD_RESET_TOKEN_TABLE', 'admin_password_reset_tokens'),
             'expire' => 60,
             'throttle' => 60,
         ],

--- a/config/session.php
+++ b/config/session.php
@@ -129,7 +129,12 @@ return [
 
     'cookie' => env(
         'SESSION_COOKIE',
-        Str::slug(env('APP_NAME', 'laravel'), '_').'_session'
+        Str::slug(env('APP_NAME', 'laravel'), '_') . '_session'
+    ),
+
+    'cookie_admin' => env(
+        'SESSION_COOKIE_ADMIN',
+        Str::slug(env('APP_NAME', 'laravel'), '_') . '_session_admin'
     ),
 
     /*

--- a/database/factories/AdminFactory.php
+++ b/database/factories/AdminFactory.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Admin>
+ */
+class AdminFactory extends Factory
+{
+    /**
+     * The current password being used by the factory.
+     */
+    protected static ?string $password;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->name(),
+            'email' => fake()->unique()->safeEmail(),
+            'email_verified_at' => now(),
+            'password' => static::$password ??= Hash::make('password'),
+            'remember_token' => Str::random(10),
+        ];
+    }
+
+    /**
+     * Indicate that the model's email address should be unverified.
+     */
+    public function unverified(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'email_verified_at' => null,
+        ]);
+    }
+}

--- a/database/migrations/2024_08_05_153334_create_admins_table.php
+++ b/database/migrations/2024_08_05_153334_create_admins_table.php
@@ -1,0 +1,49 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('admins', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->timestamp('email_verified_at')->nullable();
+            $table->string('password');
+            $table->rememberToken();
+            $table->timestamps();
+        });
+
+        Schema::create('admin_password_reset_tokens', function (Blueprint $table) {
+            $table->string('email')->primary();
+            $table->string('token');
+            $table->timestamp('created_at')->nullable();
+        });
+
+        Schema::create('admin_sessions', function (Blueprint $table) {
+            $table->string('id')->primary();
+            $table->foreignId('admin_id')->nullable()->index();
+            $table->string('ip_address', 45)->nullable();
+            $table->text('user_agent')->nullable();
+            $table->longText('payload');
+            $table->integer('last_activity')->index();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('admins');
+        Schema::dropIfExists('admin_password_reset_tokens');
+        Schema::dropIfExists('admin_sessions');
+    }
+};

--- a/database/seeders/AdminsSeeder.php
+++ b/database/seeders/AdminsSeeder.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+
+class AdminsSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        DB::table('admins')->insert([
+            [
+                'name' => 'admin',
+                'email' => 'admin@admin.com',
+                'password' => Hash::make('password'),
+                'created_at' => now()->subDays(1),
+                'updated_at' => now()->subDays(1),
+            ],
+            [
+                'name' => 'administrator',
+                'email' => 'administrator@administrator.com',
+                'password' => Hash::make('password'),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+        ]);
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -13,7 +13,8 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // User::factory(10)->create();
+        $this->call(AdminsSeeder::class);
+        $this->call(UsersSeeder::class);
 
         User::factory()->create([
             'name' => 'Test User',

--- a/database/seeders/UsersSeeder.php
+++ b/database/seeders/UsersSeeder.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+
+class UsersSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        DB::table('users')->insert([
+            [
+                'name' => 'user',
+                'email' => 'user@user.com',
+                'email_verified_at' => now()->subDays(1),
+                'password' => Hash::make('password'),
+                'created_at' => now()->subDays(1),
+                'updated_at' => now()->subDays(1),
+            ],
+            [
+                'name' => 'user2',
+                'email' => 'user2@user2.com',
+                'email_verified_at' => now(),
+                'password' => Hash::make('password'),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+            [
+                'name' => 'sample',
+                'email' => 'sample@sample.com',
+                'email_verified_at' => now(),
+                'password' => Hash::make('password'),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+        ]);
+    }
+}

--- a/resources/js/Layouts/AdminAuthenticatedLayout.tsx
+++ b/resources/js/Layouts/AdminAuthenticatedLayout.tsx
@@ -1,0 +1,181 @@
+import { useState, PropsWithChildren, ReactNode } from "react";
+import ApplicationLogo from "@/Components/ApplicationLogo";
+import Dropdown from "@/Components/Dropdown";
+import NavLink from "@/Components/NavLink";
+import ResponsiveNavLink from "@/Components/ResponsiveNavLink";
+import { Link } from "@inertiajs/react";
+import { Admin } from "@/types";
+import { useTranslation } from "react-i18next";
+
+export default function Authenticated({
+    user,
+    header,
+    children,
+}: PropsWithChildren<{ user: Admin; header?: ReactNode }>) {
+    const { t } = useTranslation();
+    const [showingNavigationDropdown, setShowingNavigationDropdown] =
+        useState(false);
+
+    return (
+        <div className="min-h-screen bg-blue-200">
+            <nav className="bg-white border-b border-gray-100">
+                <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+                    <div className="flex justify-between h-16">
+                        <div className="flex">
+                            <div className="shrink-0 flex items-center">
+                                <Link href="/">
+                                    <ApplicationLogo className="block h-16 w-auto fill-current text-gray-800" />
+                                </Link>
+                            </div>
+
+                            <div className="hidden space-x-8 sm:-my-px sm:ms-10 sm:flex">
+                                <NavLink
+                                    href={route("admin.dashboard")}
+                                    active={route().current("admin.dashboard")}
+                                >
+                                    {t("Dashboard")}
+                                </NavLink>
+                            </div>
+                        </div>
+
+                        <div className="hidden sm:flex sm:items-center sm:ms-6">
+                            <div className="ms-3 relative">
+                                <Dropdown>
+                                    <Dropdown.Trigger>
+                                        <span className="inline-flex rounded-md">
+                                            <button
+                                                type="button"
+                                                className="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-gray-500 bg-white hover:text-gray-700 focus:outline-none transition ease-in-out duration-150"
+                                            >
+                                                {user.name}
+
+                                                <svg
+                                                    className="ms-2 -me-0.5 h-4 w-4"
+                                                    xmlns="http://www.w3.org/2000/svg"
+                                                    viewBox="0 0 20 20"
+                                                    fill="currentColor"
+                                                >
+                                                    <path
+                                                        fillRule="evenodd"
+                                                        d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
+                                                        clipRule="evenodd"
+                                                    />
+                                                </svg>
+                                            </button>
+                                        </span>
+                                    </Dropdown.Trigger>
+
+                                    <Dropdown.Content>
+                                        {/* <Dropdown.Link
+                                            href={route("profile.edit")}
+                                        >
+                                            {t("Profile")}
+                                        </Dropdown.Link>
+                                        <Dropdown.Link
+                                            href={route("logout")}
+                                            method="post"
+                                            as="button"
+                                        >
+                                            {t("Log Out")}
+                                        </Dropdown.Link> */}
+                                    </Dropdown.Content>
+                                </Dropdown>
+                            </div>
+                        </div>
+
+                        <div className="-me-2 flex items-center sm:hidden">
+                            <button
+                                onClick={() =>
+                                    setShowingNavigationDropdown(
+                                        (previousState) => !previousState
+                                    )
+                                }
+                                className="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:bg-gray-100 focus:text-gray-500 transition duration-150 ease-in-out"
+                            >
+                                <svg
+                                    className="h-6 w-6"
+                                    stroke="currentColor"
+                                    fill="none"
+                                    viewBox="0 0 24 24"
+                                >
+                                    <path
+                                        className={
+                                            !showingNavigationDropdown
+                                                ? "inline-flex"
+                                                : "hidden"
+                                        }
+                                        strokeLinecap="round"
+                                        strokeLinejoin="round"
+                                        strokeWidth="2"
+                                        d="M4 6h16M4 12h16M4 18h16"
+                                    />
+                                    <path
+                                        className={
+                                            showingNavigationDropdown
+                                                ? "inline-flex"
+                                                : "hidden"
+                                        }
+                                        strokeLinecap="round"
+                                        strokeLinejoin="round"
+                                        strokeWidth="2"
+                                        d="M6 18L18 6M6 6l12 12"
+                                    />
+                                </svg>
+                            </button>
+                        </div>
+                    </div>
+                </div>
+
+                <div
+                    className={
+                        (showingNavigationDropdown ? "block" : "hidden") +
+                        " sm:hidden"
+                    }
+                >
+                    <div className="pt-2 pb-3 space-y-1">
+                        <ResponsiveNavLink
+                            href={route("admin.dashboard")}
+                            active={route().current("admin.dashboard")}
+                        >
+                            {t("Dashboard")}
+                        </ResponsiveNavLink>
+                    </div>
+
+                    <div className="pt-4 pb-1 border-t border-gray-200">
+                        <div className="px-4">
+                            <div className="font-medium text-base text-gray-800">
+                                {user.name}
+                            </div>
+                            <div className="font-medium text-sm text-gray-500">
+                                {user.email}
+                            </div>
+                        </div>
+
+                        <div className="mt-3 space-y-1">
+                            {/* <ResponsiveNavLink href={route("profile.edit")}>
+                                {t("Profile")}
+                            </ResponsiveNavLink>
+                            <ResponsiveNavLink
+                                method="post"
+                                href={route("logout")}
+                                as="button"
+                            >
+                                {t("Log Out")}
+                            </ResponsiveNavLink> */}
+                        </div>
+                    </div>
+                </div>
+            </nav>
+
+            {header && (
+                <header className="bg-white shadow">
+                    <div className="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
+                        {header}
+                    </div>
+                </header>
+            )}
+
+            <main>{children}</main>
+        </div>
+    );
+}

--- a/resources/js/Layouts/AdminGuestLayout.tsx
+++ b/resources/js/Layouts/AdminGuestLayout.tsx
@@ -1,0 +1,19 @@
+import ApplicationLogo from "@/Components/ApplicationLogo";
+import { Link } from "@inertiajs/react";
+import { PropsWithChildren } from "react";
+
+export default function Guest({ children }: PropsWithChildren) {
+    return (
+        <div className="min-h-screen flex flex-col sm:justify-center items-center pt-6 sm:pt-0 bg-blue-200">
+            <div>
+                <Link href="/">
+                    <ApplicationLogo className="w-52 h-52 fill-current text-gray-500" />
+                </Link>
+            </div>
+
+            <div className="w-full sm:max-w-md mt-6 px-6 py-4 bg-white shadow-md overflow-hidden sm:rounded-lg">
+                {children}
+            </div>
+        </div>
+    );
+}

--- a/resources/js/Pages/Admin/Auth/Login.tsx
+++ b/resources/js/Pages/Admin/Auth/Login.tsx
@@ -1,0 +1,109 @@
+import { FormEventHandler } from "react";
+import Checkbox from "@/Components/Checkbox";
+import AdminGuestLayout from "@/Layouts/AdminGuestLayout";
+import InputError from "@/Components/InputError";
+import InputLabel from "@/Components/InputLabel";
+import PrimaryButton from "@/Components/PrimaryButton";
+import TextInput from "@/Components/TextInput";
+import { Head, Link, useForm } from "@inertiajs/react";
+import { useTranslation } from "react-i18next";
+
+export default function Login({
+    status,
+    canResetPassword,
+}: {
+    status?: string;
+    canResetPassword: boolean;
+}) {
+    const { t } = useTranslation();
+    const { data, setData, post, processing, errors, reset } = useForm({
+        email: "",
+        password: "",
+        remember: false,
+    });
+
+    const submit: FormEventHandler = (e) => {
+        e.preventDefault();
+
+        post(route("admin.login"), {
+            onFinish: () => reset("password"),
+        });
+    };
+
+    return (
+        <AdminGuestLayout>
+            <Head title={t("Log in")} />
+
+            {status && (
+                <div className="mb-4 font-medium text-sm text-green-600">
+                    {status}
+                </div>
+            )}
+
+            <form onSubmit={submit}>
+                <div>
+                    <InputLabel htmlFor="email" value={t("Email")} />
+
+                    <TextInput
+                        id="email"
+                        type="email"
+                        name="email"
+                        value={data.email}
+                        className="mt-1 block w-full"
+                        autoComplete="username"
+                        isFocused={true}
+                        onChange={(e) => setData("email", e.target.value)}
+                    />
+
+                    <InputError message={errors.email} className="mt-2" />
+                </div>
+
+                <div className="mt-4">
+                    <InputLabel htmlFor="password" value={t("Password")} />
+
+                    <TextInput
+                        id="password"
+                        type="password"
+                        name="password"
+                        value={data.password}
+                        className="mt-1 block w-full"
+                        autoComplete="current-password"
+                        onChange={(e) => setData("password", e.target.value)}
+                    />
+
+                    <InputError message={errors.password} className="mt-2" />
+                </div>
+
+                <div className="block mt-4">
+                    <label className="flex items-center">
+                        <Checkbox
+                            name="remember"
+                            checked={data.remember}
+                            onChange={(e) =>
+                                setData("remember", e.target.checked)
+                            }
+                        />
+                        <span className="ms-2 text-sm text-gray-600">
+                            {t("Remember me")}
+                        </span>
+                    </label>
+                </div>
+
+                <div className="flex items-center justify-end mt-4">
+                    {canResetPassword && (
+                        <Link
+                            href={route("admin.password.request")}
+                            className="underline text-sm text-gray-600 hover:text-gray-900 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+                        >
+                            {t("Forgot your password?")}
+                        </Link>
+                    )}
+
+                    <PrimaryButton className="ms-4" disabled={processing}>
+                        {t("Log in")}
+                    </PrimaryButton>
+                </div>
+            </form>
+        </AdminGuestLayout>
+    );
+}

--- a/resources/js/Pages/Admin/Dashboard.tsx
+++ b/resources/js/Pages/Admin/Dashboard.tsx
@@ -1,0 +1,30 @@
+import AdminAuthenticatedLayout from "@/Layouts/AdminAuthenticatedLayout";
+import { Head } from "@inertiajs/react";
+import { PageProps } from "@/types";
+import { useTranslation } from "react-i18next";
+
+export default function Dashboard({ auth }: PageProps) {
+    const { t } = useTranslation();
+    return (
+        <AdminAuthenticatedLayout
+            user={auth.user}
+            header={
+                <h2 className="font-semibold text-xl text-gray-800 leading-tight">
+                    {t("Dashboard")}
+                </h2>
+            }
+        >
+            <Head title={t("Dashboard")} />
+
+            <div className="py-12">
+                <div className="max-w-7xl mx-auto sm:px-6 lg:px-8">
+                    <div className="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                        <div className="p-6 text-gray-900">
+                            {t("You're logged in!")}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </AdminAuthenticatedLayout>
+    );
+}

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -5,7 +5,16 @@ export interface User {
     email_verified_at: string;
 }
 
-export type PageProps<T extends Record<string, unknown> = Record<string, unknown>> = T & {
+export interface Admin {
+    id: number;
+    name: string;
+    email: string;
+    email_verified_at: string;
+}
+
+export type PageProps<
+    T extends Record<string, unknown> = Record<string, unknown>
+> = T & {
     auth: {
         user: User;
     };

--- a/routes/admin_auth.php
+++ b/routes/admin_auth.php
@@ -1,0 +1,59 @@
+<?php
+
+use App\Http\Controllers\Admin\Auth\AuthenticatedSessionController as AdminAuthenticatedSessionController;
+use App\Http\Controllers\Admin\Auth\ConfirmablePasswordController;
+use App\Http\Controllers\Admin\Auth\EmailVerificationNotificationController;
+use App\Http\Controllers\Admin\Auth\EmailVerificationPromptController;
+use App\Http\Controllers\Admin\Auth\NewPasswordController;
+use App\Http\Controllers\Admin\Auth\PasswordController;
+use App\Http\Controllers\Admin\Auth\PasswordResetLinkController;
+use App\Http\Controllers\Admin\Auth\RegisteredUserController as AdminRegisteredUserController;
+use App\Http\Controllers\Admin\Auth\VerifyEmailController;
+use Illuminate\Support\Facades\Route;
+
+Route::middleware('guest:admin')->prefix('admin')->name('admin.')->group(function () {
+    Route::get('/login', [AdminAuthenticatedSessionController::class, 'create'])
+        ->name('login');
+
+    Route::post('/login', [AdminAuthenticatedSessionController::class, 'store']);
+
+    //     Route::get('forgot-password', [PasswordResetLinkController::class, 'create'])
+    //         ->name('password.request');
+
+    //     Route::post('forgot-password', [PasswordResetLinkController::class, 'store'])
+    //         ->name('password.email');
+
+    //     Route::get('reset-password/{token}', [NewPasswordController::class, 'create'])
+    //         ->name('password.reset');
+
+    //     Route::post('reset-password', [NewPasswordController::class, 'store'])
+    //         ->name('password.store');
+});
+
+Route::middleware('auth:admin')->prefix('admin')->name('admin.')->group(function () {
+    // Route::get('register', [AdminRegisteredUserController::class, 'create'])
+    //     ->name('register');
+
+    // Route::post('register', [AdminRegisteredUserController::class, 'store']);
+
+    //     Route::get('verify-email', EmailVerificationPromptController::class)
+    //         ->name('verification.notice');
+
+    //     Route::get('verify-email/{id}/{hash}', VerifyEmailController::class)
+    //         ->middleware(['signed', 'throttle:6,1'])
+    //         ->name('verification.verify');
+
+    //     Route::post('email/verification-notification', [EmailVerificationNotificationController::class, 'store'])
+    //         ->middleware('throttle:6,1')
+    //         ->name('verification.send');
+
+    //     Route::get('confirm-password', [ConfirmablePasswordController::class, 'show'])
+    //         ->name('password.confirm');
+
+    //     Route::post('confirm-password', [ConfirmablePasswordController::class, 'store']);
+
+    //     Route::put('password', [PasswordController::class, 'update'])->name('password.update');
+
+    //     Route::post('logout', [AuthenticatedSessionController::class, 'destroy'])
+    //         ->name('logout');
+});

--- a/routes/web.php
+++ b/routes/web.php
@@ -24,4 +24,9 @@ Route::middleware('auth')->group(function () {
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
 });
 
-require __DIR__.'/auth.php';
+Route::get('/admin/dashboard', function () {
+    return Inertia::render('Admin/Dashboard');
+})->middleware(['auth:admin'])->name('admin.dashboard');
+
+require __DIR__ . '/auth.php';
+require __DIR__ . '/admin_auth.php';

--- a/tests/Feature/Http/Controllers/Admin/Auth/AuthenticatedSessionControllerTest.php
+++ b/tests/Feature/Http/Controllers/Admin/Auth/AuthenticatedSessionControllerTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers\Admin\Auth;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use App\Models\Admin;
+use Tests\TestCase;
+
+class AuthenticatedSessionControllerTest extends TestCase
+{
+    public function test_admin_login_screen_can_be_rendered(): void
+    {
+        $response = $this->get('/admin/login');
+
+        $response->assertStatus(200);
+    }
+
+    public function test_admins_can_authenticate_using_the_login_screen(): void
+    {
+        $admin = Admin::factory()->create();
+
+        $response = $this->post('/admin/login', [
+            'email' => $admin->email,
+            'password' => 'password',
+        ]);
+
+        $this->assertAuthenticated('admin');
+        $response->assertRedirect(route('admin.dashboard', absolute: false));
+    }
+
+    public function test_admins_can_not_authenticate_with_invalid_password(): void
+    {
+        $user = Admin::factory()->create();
+
+        $this->post('/login', [
+            'email' => $user->email,
+            'password' => 'wrong-password',
+        ]);
+
+        $this->assertGuest();
+    }
+}


### PR DESCRIPTION
<BLANK LINE>
管理者用の login test 機能を追加<br>
管理者用の Migration, Seeder, Factory, Model, Route を追加<br>
管理者用の login 機能を追加<br>
管理者用の認証(guard)を作成<br>
管理者とユーザーのセッションクッキーを分割し、マルチログイン実装<br>
管理者、ユーザーが認証されている状態で login 画面に遷移使用した場合redirectされる機能を追加<br>