### PR TITLE
[Fix icon redirect][admin] 管理者画面のアイコンリダイレクト先を修正

### DIFF
--- a/resources/js/Layouts/AdminAuthenticatedLayout.tsx
+++ b/resources/js/Layouts/AdminAuthenticatedLayout.tsx
@@ -25,7 +25,7 @@ export default function Authenticated({
                     <div className="flex justify-between h-16">
                         <div className="flex">
                             <div className="shrink-0 flex items-center">
-                                <Link href="/">
+                                <Link href="/admin/dashboard">
                                     <ApplicationLogo className="block h-16 w-auto fill-current text-gray-800" />
                                 </Link>
                             </div>


### PR DESCRIPTION
<BLANK LINE>
F0001<br><br>

アイコン押下時にユーザーのwelcomeに遷移していたのを管理者のdashboardに修正