### PR TITLE
[Fix uniformity in writing layout links][user, admin] 顧客、管理者画面のlayoutに記載してあるlinkの記述を統一する修正

### DIFF
--- a/resources/js/Layouts/AdminAuthenticatedLayout.tsx
+++ b/resources/js/Layouts/AdminAuthenticatedLayout.tsx
@@ -33,7 +33,7 @@ export default function Authenticated({
                             <div className="hidden space-x-8 sm:-my-px sm:ms-10 sm:flex">
                                 <NavLink
                                     href={route("admin.dashboard")}
-                                    active={route().current("admin.dashboard")}
+                                    active={component === "Admin/Dashboard"}
                                 >
                                     {t("Dashboard")}
                                 </NavLink>
@@ -143,7 +143,7 @@ export default function Authenticated({
                     <div className="pt-2 pb-3 space-y-1">
                         <ResponsiveNavLink
                             href={route("admin.dashboard")}
-                            active={route().current("admin.dashboard")}
+                            active={component === "Admin/Dashboard"}
                         >
                             {t("Dashboard")}
                         </ResponsiveNavLink>
@@ -168,6 +168,7 @@ export default function Authenticated({
                         <div className="mt-3 space-y-1">
                             <ResponsiveNavLink
                                 href={route("admin.profile.edit")}
+                                active={component === "Admin/Profile/Edit"}
                             >
                                 {t("Profile")}
                             </ResponsiveNavLink>

--- a/resources/js/Layouts/AuthenticatedLayout.tsx
+++ b/resources/js/Layouts/AuthenticatedLayout.tsx
@@ -6,6 +6,7 @@ import ResponsiveNavLink from "@/Components/ResponsiveNavLink";
 import { Link } from "@inertiajs/react";
 import { User } from "@/types";
 import { useTranslation } from "react-i18next";
+import { usePage } from "@inertiajs/react";
 
 export default function Authenticated({
     user,
@@ -13,6 +14,7 @@ export default function Authenticated({
     children,
 }: PropsWithChildren<{ user: User; header?: ReactNode }>) {
     const { t } = useTranslation();
+    const { component } = usePage();
     const [showingNavigationDropdown, setShowingNavigationDropdown] =
         useState(false);
 
@@ -31,7 +33,7 @@ export default function Authenticated({
                             <div className="hidden space-x-8 sm:-my-px sm:ms-10 sm:flex">
                                 <NavLink
                                     href={route("dashboard")}
-                                    active={route().current("dashboard")}
+                                    active={component === "Dashboard"}
                                 >
                                     {t("Dashboard")}
                                 </NavLink>
@@ -135,7 +137,7 @@ export default function Authenticated({
                     <div className="pt-2 pb-3 space-y-1">
                         <ResponsiveNavLink
                             href={route("dashboard")}
-                            active={route().current("dashboard")}
+                            active={component === "Dashboard"}
                         >
                             {t("Dashboard")}
                         </ResponsiveNavLink>
@@ -152,7 +154,10 @@ export default function Authenticated({
                         </div>
 
                         <div className="mt-3 space-y-1">
-                            <ResponsiveNavLink href={route("profile.edit")}>
+                            <ResponsiveNavLink
+                                href={route("profile.edit")}
+                                active={component === "Profile/Edit"}
+                            >
                                 {t("Profile")}
                             </ResponsiveNavLink>
                             <ResponsiveNavLink


### PR DESCRIPTION
<BLANK LINE>
F0002<br><br>

現在のページをuiで表示するのに利用しているlinkのactiveをroute()からInertia の usePage フックを使用して現在のコンポーネント名で指定