### PR TITLE
[Fix test user logout redirect][user] 顧客のログアウト後を確認するテストでのエラーを修正

### DIFF
--- a/tests/Feature/Auth/AuthenticationTest.php
+++ b/tests/Feature/Auth/AuthenticationTest.php
@@ -49,6 +49,6 @@ class AuthenticationTest extends TestCase
         $response = $this->actingAs($user)->post('/logout');
 
         $this->assertGuest();
-        $response->assertRedirect('/');
+        $response->assertRedirect('/login');
     }
 }


### PR DESCRIPTION
<BLANK LINE>
F0008<br><br>

loguout処理のテスト後redirectを / から /login に修正